### PR TITLE
feat: add Netlify deploy config with SVG-to-PNG OG image conversion

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,13 @@
+[build]
+  command = "pnpm run build"
+  publish = "dist"
+
+[[redirects]]
+  from = "/"
+  to = "/es"
+  status = 302
+
+[[headers]]
+  for = "/*/og-image.png"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node scripts/convert-og.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/scripts/convert-og.mjs
+++ b/scripts/convert-og.mjs
@@ -1,0 +1,57 @@
+import { execSync } from "child_process";
+import { existsSync, readdirSync, renameSync } from "fs";
+import { join } from "path";
+
+const distDir = new URL("../dist", import.meta.url).pathname;
+
+function findSvgs(dir) {
+  const results = [];
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...findSvgs(fullPath));
+      } else if (entry.name === "og-image.svg") {
+        results.push(fullPath);
+      }
+    }
+  } catch {}
+  return results;
+}
+
+const svgs = findSvgs(distDir);
+
+if (svgs.length === 0) {
+  console.log("No OG SVG files found, skipping conversion");
+  process.exit(0);
+}
+
+for (const svgPath of svgs) {
+  const pngPath = svgPath.replace(/\.svg$/, ".png");
+  console.log(`Converting ${svgPath} → ${pngPath}`);
+
+  const tools = [
+    { cmd: "rsvg-convert", args: ["rsvg-convert", "-f", "png", "-o", pngPath, svgPath] },
+    { cmd: "magick", args: ["magick", "convert", svgPath, pngPath] },
+    { cmd: "convert", args: ["convert", svgPath, pngPath] },
+  ];
+
+  let converted = false;
+  for (const tool of tools) {
+    try {
+      execSync(tool.args.join(" "), { stdio: "pipe" });
+      if (existsSync(pngPath)) {
+        console.log(`  ✓ converted with ${tool.cmd}`);
+        converted = true;
+        break;
+      }
+    } catch {}
+  }
+
+  if (!converted) {
+    console.log(`  ✗ no conversion tool available, keeping SVG as fallback`);
+  }
+}
+
+console.log("OG image conversion complete");

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,8 +30,8 @@ const siteDescription =
 
 const ogTitle =
   lang === "en"
-    ? "dabetai — Predict diabetes complications with AI | App & medical portal"
-    : "dabetai — Predice complicaciones de la diabetes con IA | App y portal médico";
+    ? "dabetai — Predict diabetes complications with AI"
+    : "dabetai — Predice complicaciones de diabetes con IA";
 
 const ogDescription =
   lang === "en"
@@ -66,10 +66,10 @@ const wsDescription =
 
 		<meta property="og:title" content={ogTitle} />
 		<meta property="og:description" content={ogDescription} />
-		<meta property="og:image" content={`${siteUrl}/${lang}/og-image.svg`} />
+		<meta property="og:image" content={`${siteUrl}/${lang}/og-image.png`} />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta property="og:image:type" content="image/svg+xml" />
+		<meta property="og:image:type" content="image/png" />
 		<meta property="og:type" content="website" />
 		<meta property="og:locale" content={ogLocale} />
 		<meta property="og:site_name" content="dabetai" />
@@ -78,7 +78,7 @@ const wsDescription =
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content={ogTitle} />
 		<meta name="twitter:description" content={ogDescription} />
-		<meta name="twitter:image" content={`${siteUrl}/${lang}/og-image.svg`} />
+		<meta name="twitter:image" content={`${siteUrl}/${lang}/og-image.png`} />
 		<meta name="twitter:image:width" content="1200" />
 		<meta name="twitter:image:height" content="630" />
 


### PR DESCRIPTION
## Summary

- Add `netlify.toml` with build command, publish dir, / → /es redirect, and PNG cache headers
- Add `scripts/convert-og.mjs` — post-build SVG→PNG conversion (rsvg-convert → magick → convert)
- Update `package.json` build script to run conversion after `astro build`
- Shorten OG titles (under 55 chars) and switch meta tags from `.svg` to `.png`